### PR TITLE
feat: fly key settings

### DIFF
--- a/src/defaults/video.ts
+++ b/src/defaults/video.ts
@@ -239,6 +239,13 @@ export function flyKeyframe(id: number): VideoState.USK.UpstreamKeyerFlyKeyframe
 	}
 }
 
+export const FlyKeyProperties: VideoState.USK.UpstreamKeyerFlySettings = {
+	isASet: false,
+	isBSet: false,
+	isAtKeyFrame: Enums.IsAtKeyFrame.None,
+	runToInfiniteIndex: Enums.FlyKeyDirection.CentreOfKey,
+}
+
 export const SuperSourceBox: VideoState.SuperSource.SuperSourceBox = {
 	enabled: false,
 	source: defaultInput,

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -48,6 +48,7 @@ export function DiffAllObject(): DeepComplete<SectionsToDiff> {
 					mask: true,
 
 					flyKeyframes: 'all',
+					flyProperties: true,
 					dveSettings: true,
 					chromaSettings: true,
 					advancedChromaSettings: true,
@@ -162,6 +163,7 @@ export interface DiffUpstreamKeyer {
 	mask?: boolean
 
 	flyKeyframes?: number[] | 'all'
+	flyProperties?: boolean
 	dveSettings?: boolean
 	chromaSettings?: boolean
 	advancedChromaSettings?: boolean

--- a/src/resolvers/upstreamKeyers/index.ts
+++ b/src/resolvers/upstreamKeyers/index.ts
@@ -6,7 +6,7 @@ import { resolvePatternKeyerState } from './patternKeyer'
 import { getAllKeysNumber, diffObject, fillDefaults } from '../../util'
 import { PartialDeep } from 'type-fest'
 import * as Defaults from '../../defaults'
-import { resolveFlyKeyerFramesState } from './flyKey'
+import { resolveFlyKeyerFramesState, resolveFlyPropertiesState } from './flyKey'
 import { DiffUpstreamKeyer } from '../../diff'
 
 export function resolveUpstreamKeyerState(
@@ -41,6 +41,11 @@ export function resolveUpstreamKeyerState(
 					newKeyer.flyKeyframes,
 					thisDiffOptions.flyKeyframes
 				)
+			)
+		}
+		if (thisDiffOptions.flyProperties) {
+			commands.push(
+				...resolveFlyPropertiesState(mixEffectId, upstreamKeyerId, oldKeyer.flyProperties, newKeyer.flyProperties)
 			)
 		}
 


### PR DESCRIPTION
This PR adds additional state diff for Blackmagic Atem's flying key functionality. Currently the flying key keyframes can already be set, but it is not possible to run to a keyframe.

This PR is raised by SuperFly.tv on behalf of BBC.