### PR TITLE
ci: set persist-credentials to false for checkout action

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -16,7 +16,10 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
@@ -44,7 +47,10 @@ jobs:
         node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -84,8 +90,10 @@ jobs:
       - validate-dependencies
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Git checkout
+        uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
@@ -150,7 +158,10 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:
@@ -177,7 +188,10 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,10 @@ jobs:
         node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Git checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -41,8 +44,10 @@ jobs:
       - test
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Git checkout
+        uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4


### PR DESCRIPTION
With this setting credentials are removed from the git configuration before the action completes.